### PR TITLE
Add site format documentation

### DIFF
--- a/DIFF_20250616_011452.md
+++ b/DIFF_20250616_011452.md
@@ -1,0 +1,3 @@
+## Diff for 2025-06-16 01:14 UTC
+- Added `docs/` folder.
+- Created `docs/site-format.md` outlining website theme, layout framework, recommended pages, and content ideas.

--- a/RECOMMENDATIONS_20250616_011452.md
+++ b/RECOMMENDATIONS_20250616_011452.md
@@ -1,0 +1,4 @@
+## Recommendations as of 2025-06-16 01:14 UTC
+- Build a reusable layout component (header, footer, container) to enforce consistency across pages.
+- Use Markdown files for blog posts and a small CMS for updates.
+- Consider adding tests for frontend components with React Testing Library.

--- a/docs/site-format.md
+++ b/docs/site-format.md
@@ -8,6 +8,11 @@ This document outlines the visual theme, layout framework, and recommended pages
 - **Animations**: subtle Framer Motion or Lottie animations to emphasize interactions without overwhelming the user.
 - **Layout**: responsive design that centers content with generous spacing.
 
+## Accessibility
+- **Color Contrast**: Ensure all text and interactive elements meet WCAG AA contrast ratios (e.g., neon colors on a charcoal background may require adjustments).
+- **Keyboard Navigation**: All interactive elements (e.g., links, buttons) must be navigable and operable via keyboard.
+- **ARIA Roles**: Use appropriate ARIA roles and attributes to enhance screen reader compatibility.
+- **Responsive Design**: Ensure layouts adapt seamlessly to different screen sizes and orientations, including zoom functionality.
 ## Layout Framework
 - **Header / Navbar**: fixed or sticky navigation with links to main sections.
 - **Footer**: includes quick links, social media icons, and contact info.

--- a/docs/site-format.md
+++ b/docs/site-format.md
@@ -1,0 +1,31 @@
+# Website Format & Page Plan
+
+This document outlines the visual theme, layout framework, and recommended pages for **iongiveafuq.com**.
+
+## Visual Theme
+- **Color Palette**: charcoal background with neon-pink, neon-green, and neon-blue accents (see `tailwind.config.js`).
+- **Typography**: bold sans-serif fonts, all caps headings.
+- **Animations**: subtle Framer Motion or Lottie animations to emphasize interactions without overwhelming the user.
+- **Layout**: responsive design that centers content with generous spacing.
+
+## Layout Framework
+- **Header / Navbar**: fixed or sticky navigation with links to main sections.
+- **Footer**: includes quick links, social media icons, and contact info.
+- **Main Container**: uniform max width with padding, used across pages.
+- **Global Styles**: apply `min-h-screen bg-gray-900 text-white` to body.
+
+## Recommended Pages
+1. **Home** – introduction and call-to-action.
+2. **Store** – product listings and checkout.
+3. **About** – background on the brand and mascots.
+4. **FAQ** – frequently asked questions presented humorously.
+5. **Contact** – contact form and social links.
+6. **Blog** – posts about updates, behind-the-scenes content.
+7. **Privacy Policy** and **Terms** – standard legal pages.
+
+## Content Expansion Ideas
+- **Mascot Bios**: dedicated pages for each mascot with art and short bios.
+- **Comic Strips**: short, dark-humor comics featuring the mascots.
+- **User-Generated Memes**: allow visitors to submit memes or slogans.
+- **Merchandising**: digital downloads or printable assets.
+


### PR DESCRIPTION
## Summary
- define the overall visual theme and layout framework
- outline suggested pages to create
- brainstorm additional content ideas

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f6fce8de4832ab70381958e52a05c

## Summary by Sourcery

Add documentation outlining the website’s visual theme, layout framework, recommended pages, and content expansion ideas, and include timestamped recommendation and diff snapshot files for future reference.

Documentation:
- Create `docs/site-format.md` to define color palette, typography, animations, layout framework, and recommended pages.
- Add a timestamped recommendations file to suggest reusable layout components, CMS usage, and frontend testing.
- Add a timestamped diff snapshot file to document the initial addition of the docs folder and site-format documentation.