### PR TITLE
Add docs landing page and index

### DIFF
--- a/DIFF_2025-07-23_14-45-22.md
+++ b/DIFF_2025-07-23_14-45-22.md
@@ -1,0 +1,4 @@
+- Added docs/landing-page.md as a simple landing page with links to other docs
+- Added docs/site-index.md listing key documentation and app directories
+- Added docs/artwork-prompts.md containing mascot art prompts
+- Updated README with links to landing page and site index

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ frontend/   React + Vite web app
 context.md  In-depth context with code listing
 ```
 
+See `docs/landing-page.md` for a curated entry point and `docs/site-index.md` to navigate all documentation.
+
 ## Running Locally
 
 ### Frontend dev server

--- a/RECOMMENDATIONS_2025-07-23_14-45-22.md
+++ b/RECOMMENDATIONS_2025-07-23_14-45-22.md
@@ -1,0 +1,3 @@
+## 2025-07-23 14:45 UTC
+- Consider turning `docs` into a simple static site using a generator like MkDocs
+- Add art assets to the artwork directory using the new prompts as guidance

--- a/docs/artwork-prompts.md
+++ b/docs/artwork-prompts.md
@@ -1,0 +1,20 @@
+# Artwork Prompts
+
+Use these text prompts to generate or refine art for the project mascots.
+
+## Buzz the Donkey
+- "Buzz the drunken cyberpunk donkey, leaning against a neon-lit alleyway, expressive cartoon style, vibrant pink and blue lighting"
+
+## Dumbo the Dog
+- "Dumbo the ugly but lovable dog wearing a ragged hoodie, standing under a flickering street sign, gritty comic shading"
+
+## Scrapz the Cat
+- "Scrapz the ragged alley cat with torn ears, perched on a trashcan throne, darkly humorous vibe"
+
+## Patty LaHam the Pig
+- "Patty LaHam the eccentric punk pig with a mohawk, tossing confetti in a crowded nightclub, saturated neon palette"
+
+## Rizzo the Rat
+- "Rizzo the scheming rat mastermind plotting in a sewer lair, dramatic shadows and green highlights"
+
+Feel free to remix these descriptions or adapt them for AI image generation tools.

--- a/docs/landing-page.md
+++ b/docs/landing-page.md
@@ -1,0 +1,10 @@
+# iongiveafuq Landing Page
+
+Welcome to **iongiveafuq** – a neon-soaked hub for dark-humor merch and mascot lore. This landing page serves as a quick starting point for exploring the project.
+
+- **Visit the [Site Index](site-index.md)** for a list of available docs
+- **Check out the [Frontend App](../frontend/index.html)** to run the React site locally
+- **Browse our [Mascot Backstories](characters)** to learn about Buzz, Dumbo, Scrapz, Patty LaHam, and Rizzo
+- **Explore [Storylines](storylines/Mascot_Storylines.md)** for a taste of their adventures
+
+Artwork assets live in the [artwork](../artwork) directory. See [Artwork Prompts](artwork-prompts.md) to generate new pieces.

--- a/docs/site-index.md
+++ b/docs/site-index.md
@@ -1,0 +1,16 @@
+# Site Index
+
+This index lists the main documentation pages and assets included in the repository.
+
+## Documentation
+- [Landing Page](landing-page.md)
+- [Website Format](site-format.md)
+- [Mascot Backstories](characters)
+- [Storylines](storylines/Mascot_Storylines.md)
+- [Artwork Prompts](artwork-prompts.md)
+
+## Application
+- [Frontend React App](../frontend)
+- [Backend API](../backend)
+
+Use this index to quickly navigate the repo and find content to update or expand.


### PR DESCRIPTION
## Summary
- add landing page, site index, and art prompts under docs
- link new docs from README

## Testing
- `npm test --prefix frontend` *(fails: 2 failed, 1 passed)*
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6880f529e528832abfb1953f0d49fbde